### PR TITLE
engine.py: don't use SessionHook

### DIFF
--- a/python/engine.py
+++ b/python/engine.py
@@ -104,7 +104,7 @@ def engine_start():
 
     unsaved = []
     while (_is_running):
-        event = nvim.session.next_message()
+        event = nvim.next_message()
         if not event:
             continue
 
@@ -182,13 +182,13 @@ def engine_start():
 
             result = {'cursor':str(cursor), 'cursor.kind': str(cursor.kind), 'cursor.type.kind': str(cursor.type.kind), 'cursor.spelling' : cursor.spelling}
             event[3].send(result)
-            
+
         elif event[1] == 'update_unsaved_all':
             _update_unsaved_all(nvim, unsaved)
             event[3].send('ok')
 
         elif event[1] == 'shutdown':
-            nvim.session.stop()
+            nvim.stop()
             _is_running = False
             event[3].send('ok')
 


### PR DESCRIPTION
Commit 6655ced441ebc7a8ebad3649e5962a238bea20c3 of neovim python-client
removed the SessionHook because of this engine.py fails if it tries to
access nvim.session. This patch fixes this issue.

Signed-off-by: Stefan Eichenberger eichest@gmail.com
